### PR TITLE
Update CultureInfo.xml

### DIFF
--- a/xml/System.Globalization/CultureInfo.xml
+++ b/xml/System.Globalization/CultureInfo.xml
@@ -151,7 +151,10 @@
 -   Replacement cultures whose properties are different from the properties of the standard cultures supported by Windows and the .NET Framework.  
   
 -   Standard cultures with user overrides. The user can use the **Region and Language** application in **Control Panel** to customize an existing culture's property values.  
-    
+  
+> [!NOTE]
+>  You can use the <xref:System.Globalization.CultureAndRegionInfoBuilder> class to define, save, and register custom cultures that either supplement or replace existing cultures. The <xref:System.Globalization.CultureAndRegionInfoBuilder.Save%2A?displayProperty=nameWithType> method creates a Locale Data Markup Language (LDML) file that can be used to install a custom culture on target systems. For step-by step information on using the <xref:System.Globalization.CultureAndRegionInfoBuilder> class to create a new or replacement culture, see the <xref:System.Globalization.CultureAndRegionInfoBuilder> class topic.  
+  
  Because the .NET Framework supports custom cultures, you should consider the following when working with culture-specific data:  
   
 -   Custom cultures can have values that exceed the ranges of the predefined cultures. For example, some cultures have unusually long month names, unexpected date or time formats, or other unusual data.  
@@ -371,6 +374,7 @@ In .NET Framework and .NET Core apps, the current culture is a per-thread settin
   
  ]]></format>
     </remarks>
+    <altmember cref="T:System.Globalization.CultureAndRegionInfoBuilder" />
     <altmember cref="T:System.Globalization.RegionInfo" />
   </Docs>
   <Members>
@@ -2060,6 +2064,7 @@ csc /resource:GreetingStrings.resources Example1.cs
 |Vietnamese|vi|en-US|  
 |Vietnamese (Vietnam)|vi-VN|en-US|  
   
+ Your application can use <xref:System.Globalization.CultureAndRegionInfoBuilder> to create a replacement for a culture, and that culture can have a console fallback culture of your choosing.  
   
    
   
@@ -2384,6 +2389,7 @@ Setting `predefinedOnly` to `true` will ensure a culture is created only if the 
           <para>The [!INCLUDE[net_v35_long](~/includes/net-v35-long-md.md)] and earlier versions throw an <see cref="T:System.ArgumentException" /> if <paramref name="name" /> does not correspond to the name of a supported culture. Starting with the [!INCLUDE[net_v40_long](~/includes/net-v40-long-md.md)], this method throws a <see cref="T:System.Globalization.CultureNotFoundException" />.</para>
         </block>
         <altmember cref="P:System.Globalization.CultureInfo.TextInfo" />
+        <altmember cref="T:System.Globalization.CultureAndRegionInfoBuilder" />
         <altmember cref="M:System.Globalization.CultureInfo.ClearCachedData" />
       </Docs>
     </Member>
@@ -2658,6 +2664,7 @@ Setting `predefinedOnly` to `true` will ensure a culture is created only if the 
  ]]></format>
         </remarks>
         <altmember cref="P:System.Globalization.CultureInfo.TextInfo" />
+        <altmember cref="T:System.Globalization.CultureAndRegionInfoBuilder" />
       </Docs>
     </Member>
     <Member MemberName="InstalledUICulture">

--- a/xml/System.Globalization/CultureInfo.xml
+++ b/xml/System.Globalization/CultureInfo.xml
@@ -2066,7 +2066,6 @@ csc /resource:GreetingStrings.resources Example1.cs
 |Vietnamese|vi|en-US|  
 |Vietnamese (Vietnam)|vi-VN|en-US|  
   
- Your .NET Framework application can use <xref:System.Globalization.CultureAndRegionInfoBuilder> to create a replacement for a culture, and that culture can have a console fallback culture of your choosing.  
   
    
   

--- a/xml/System.Globalization/CultureInfo.xml
+++ b/xml/System.Globalization/CultureInfo.xml
@@ -112,7 +112,7 @@
   
  Certain predefined culture names and identifiers are used by this and other classes in the <xref:System.Globalization?displayProperty=nameWithType> namespace. For detailed culture information for Windows systems, see the **Language tag** column in the [list of language/region names supported by Windows](https://docs.microsoft.com/openspecs/windows_protocols/ms-lcid/a9eac961-e77d-41a6-90a5-ce1a8b0cdb9c). Culture names follow the standard defined by [BCP 47](https://tools.ietf.org/html/bcp47).  
   
- Remember that the culture names and identifiers represent only a subset of cultures that can be found on a particular computer. Windows versions or service packs can change the available cultures. Applications add custom cultures using the <xref:System.Globalization.CultureAndRegionInfoBuilder> class. Users add their own custom cultures using the Microsoft Locale Builder tool. Microsoft Locale Builder is written in managed code using the `CultureAndRegionInfoBuilder` class.  
+ Remember that the culture names and identifiers represent only a subset of cultures that can be found on a particular computer. Windows versions or service packs can change the available cultures. Applications add custom cultures using the <xref:System.Globalization.CultureAndRegionInfoBuilder> class. Users add their own custom cultures using the [Microsoft Locale Builder](https://www.microsoft.com/en-us/download/details.aspx?id=41158) tool. [Microsoft Locale Builder](https://www.microsoft.com/en-us/download/details.aspx?id=41158) is written in managed code using the `CultureAndRegionInfoBuilder` class.  
   
  Several distinct names are closely associated with a culture, notably the names associated with the following class members:  
   
@@ -153,7 +153,8 @@
 -   Standard cultures with user overrides. The user can use the **Region and Language** application in **Control Panel** to customize an existing culture's property values.  
   
 > [!NOTE]
->  In .NET Framework, you can use the <xref:System.Globalization.CultureAndRegionInfoBuilder> class to define, save, and register custom cultures that either supplement or replace existing cultures. The <xref:System.Globalization.CultureAndRegionInfoBuilder.Save%2A?displayProperty=nameWithType> method creates a Locale Data Markup Language (LDML) file that can be used to install a custom culture on target systems. For step-by step information on using the <xref:System.Globalization.CultureAndRegionInfoBuilder> class to create a new or replacement culture, see the <xref:System.Globalization.CultureAndRegionInfoBuilder> class topic.  
+>  We recommend you to use the [Microsoft Locale Builder](https://www.microsoft.com/en-us/download/details.aspx?id=41158) to register your custom cultures on the Windows operating system.
+>  Alternatively, in .NET Framework, you can use the <xref:System.Globalization.CultureAndRegionInfoBuilder> class to define, save, and register custom cultures that either supplement or replace existing cultures. The <xref:System.Globalization.CultureAndRegionInfoBuilder.Save%2A?displayProperty=nameWithType> method creates a Locale Data Markup Language (LDML) file that can be used to install a custom culture on target systems. For step-by step information on using the <xref:System.Globalization.CultureAndRegionInfoBuilder> class to create a new or replacement culture, see the <xref:System.Globalization.CultureAndRegionInfoBuilder> class topic.
   
  Because the .NET supports custom cultures, you should consider the following when working with culture-specific data:  
   

--- a/xml/System.Globalization/CultureInfo.xml
+++ b/xml/System.Globalization/CultureInfo.xml
@@ -153,15 +153,15 @@
 -   Standard cultures with user overrides. The user can use the **Region and Language** application in **Control Panel** to customize an existing culture's property values.  
   
 > [!NOTE]
->  You can use the <xref:System.Globalization.CultureAndRegionInfoBuilder> class to define, save, and register custom cultures that either supplement or replace existing cultures. The <xref:System.Globalization.CultureAndRegionInfoBuilder.Save%2A?displayProperty=nameWithType> method creates a Locale Data Markup Language (LDML) file that can be used to install a custom culture on target systems. For step-by step information on using the <xref:System.Globalization.CultureAndRegionInfoBuilder> class to create a new or replacement culture, see the <xref:System.Globalization.CultureAndRegionInfoBuilder> class topic.  
+>  For .NET Framework, you can use the <xref:System.Globalization.CultureAndRegionInfoBuilder> class to define, save, and register custom cultures that either supplement or replace existing cultures. The <xref:System.Globalization.CultureAndRegionInfoBuilder.Save%2A?displayProperty=nameWithType> method creates a Locale Data Markup Language (LDML) file that can be used to install a custom culture on target systems. For step-by step information on using the <xref:System.Globalization.CultureAndRegionInfoBuilder> class to create a new or replacement culture, see the <xref:System.Globalization.CultureAndRegionInfoBuilder> class topic.  
   
- Because the .NET Framework supports custom cultures, you should consider the following when working with culture-specific data:  
+ Because the .NET supports custom cultures, you should consider the following when working with culture-specific data:  
   
 -   Custom cultures can have values that exceed the ranges of the predefined cultures. For example, some cultures have unusually long month names, unexpected date or time formats, or other unusual data.  
   
 -   When you display culture-specific data in the user interface, you should respect the user's customizations; for example, the user might want a 24-hour clock or a yyyyMMdd date format.  
   
--   Remember that custom cultures override default values. Therefore, you cannot consider culture data to be stable. Country names, number and date formats, and spellings may change in the future. If you want to serialize culture-sensitive data such as date and time strings to be passed to the date and time parsing functions, you should use the invariant culture or a specific .  
+-   Remember that custom cultures override default values. Therefore, you cannot consider culture data to be stable. Country names, number and date formats, and spellings may change in the future. If you want to serialize culture-sensitive data such as date and time strings to be passed to the date and time parsing functions, you should use the invariant culture or a specific culture.  
   
  The <xref:System.Globalization.CultureInfo.CultureTypes%2A> property value of custom cultures installed on a system includes the <xref:System.Globalization.CultureTypes?displayProperty=nameWithType> flag, and custom cultures are assigned an <xref:System.Globalization.CultureInfo.LCID%2A> property value of `LOCALE_CUSTOM_UNSPECIFIED` (0x1000, or 4096). Note that, starting with Windows 10, this value is also assigned to system-defined cultures that lack complete cultural data.  
 
@@ -171,11 +171,13 @@
 
 - In .NET Framework 3.5 and earlier versions, cultural data is provided by both the Windows operating system and the .NET Framework.
 
-- In .NET Framework 4 and later versions, cultural data is provided by the Windows operating system.
+- In .NET Framework 4 and later versions, cultural data is provided by the Windows operating system through [National Language Support (NLS)](https://docs.microsoft.com/en-us/windows/win32/intl/national-language-support).
 
-- In all versions of .NET Core running on Windows, cultural data is provided by the Windows operating system.
+- In .NET 5 (and all versions .NET Core) running on Windows, cultural data is provided by the Windows operating system through [National Language Support (NLS)](https://docs.microsoft.com/en-us/windows/win32/intl/national-language-support).
 
-- In all versions of .NET Core running on Unix platforms, cultural data is provided by the [International Components for Unicode (ICU) Library](http://site.icu-project.org/). The specific version of the ICU Library depends on the individual operating system.
+- In .NET 5 (and all versions of .NET Core) running on Unix platforms, cultural data is provided by the [International Components for Unicode (ICU) Library](http://site.icu-project.org/). The specific version of the ICU Library depends on the individual operating system.
+
+- Starting from .NET 5, cultural data is provided by the [International Components for Unicode (ICU) Library](http://site.icu-project.org/) by default when running on Windows 10 May 2019 Update or later. See the [.NET globalization and ICU](https://docs.microsoft.com/en-us/dotnet/standard/globalization-localization/globalization-icu) article for behavioral differences.
 
 Because of this, a culture available on a particular .NET implementation, platform, or version may not be available on a different .NET implementation, platform, or version.
 
@@ -2064,7 +2066,7 @@ csc /resource:GreetingStrings.resources Example1.cs
 |Vietnamese|vi|en-US|  
 |Vietnamese (Vietnam)|vi-VN|en-US|  
   
- Your application can use <xref:System.Globalization.CultureAndRegionInfoBuilder> to create a replacement for a culture, and that culture can have a console fallback culture of your choosing.  
+ Your .NET Framework application can use <xref:System.Globalization.CultureAndRegionInfoBuilder> to create a replacement for a culture, and that culture can have a console fallback culture of your choosing.  
   
    
   

--- a/xml/System.Globalization/CultureInfo.xml
+++ b/xml/System.Globalization/CultureInfo.xml
@@ -153,7 +153,7 @@
 -   Standard cultures with user overrides. The user can use the **Region and Language** application in **Control Panel** to customize an existing culture's property values.  
   
 > [!NOTE]
->  For .NET Framework, you can use the <xref:System.Globalization.CultureAndRegionInfoBuilder> class to define, save, and register custom cultures that either supplement or replace existing cultures. The <xref:System.Globalization.CultureAndRegionInfoBuilder.Save%2A?displayProperty=nameWithType> method creates a Locale Data Markup Language (LDML) file that can be used to install a custom culture on target systems. For step-by step information on using the <xref:System.Globalization.CultureAndRegionInfoBuilder> class to create a new or replacement culture, see the <xref:System.Globalization.CultureAndRegionInfoBuilder> class topic.  
+>  In .NET Framework, you can use the <xref:System.Globalization.CultureAndRegionInfoBuilder> class to define, save, and register custom cultures that either supplement or replace existing cultures. The <xref:System.Globalization.CultureAndRegionInfoBuilder.Save%2A?displayProperty=nameWithType> method creates a Locale Data Markup Language (LDML) file that can be used to install a custom culture on target systems. For step-by step information on using the <xref:System.Globalization.CultureAndRegionInfoBuilder> class to create a new or replacement culture, see the <xref:System.Globalization.CultureAndRegionInfoBuilder> class topic.  
   
  Because the .NET supports custom cultures, you should consider the following when working with culture-specific data:  
   
@@ -173,7 +173,7 @@
 
 - In .NET Framework 4 and later versions, cultural data is provided by the Windows operating system through [National Language Support (NLS)](https://docs.microsoft.com/en-us/windows/win32/intl/national-language-support).
 
-- In .NET 5 (and all versions .NET Core) running on Windows, cultural data is provided by the Windows operating system through [National Language Support (NLS)](https://docs.microsoft.com/en-us/windows/win32/intl/national-language-support).
+- In all versions of .NET Core running on Windows, cultural data is provided by the Windows operating system through [National Language Support (NLS)](https://docs.microsoft.com/en-us/windows/win32/intl/national-language-support).
 
 - In .NET 5 (and all versions of .NET Core) running on Unix platforms, cultural data is provided by the [International Components for Unicode (ICU) Library](http://site.icu-project.org/). The specific version of the ICU Library depends on the individual operating system.
 

--- a/xml/System.Globalization/CultureInfo.xml
+++ b/xml/System.Globalization/CultureInfo.xml
@@ -154,6 +154,7 @@
   
 > [!NOTE]
 >  You can use the [Microsoft Locale Builder](https://www.microsoft.com/en-us/download/details.aspx?id=41158) to create and register your custom cultures on the Windows operating system.
+>  Although the <xref:System.Globalization.CultureAndRegionInfoBuilder> class serves for the same purpose, it is not recommended as the <xref:System.Globalization.CultureAndRegionInfoBuilder> class does not apply to .NET Core and later versions.
 
  Because the .NET supports custom cultures, you should consider the following when working with culture-specific data:  
   
@@ -2066,6 +2067,7 @@ csc /resource:GreetingStrings.resources Example1.cs
 |Vietnamese|vi|en-US|  
 |Vietnamese (Vietnam)|vi-VN|en-US|  
   
+ Your application can use <xref:System.Globalization.CultureAndRegionInfoBuilder> to create a replacement for a culture, and that culture can have a console fallback culture of your choosing. 
   
    
   

--- a/xml/System.Globalization/CultureInfo.xml
+++ b/xml/System.Globalization/CultureInfo.xml
@@ -151,10 +151,7 @@
 -   Replacement cultures whose properties are different from the properties of the standard cultures supported by Windows and the .NET Framework.  
   
 -   Standard cultures with user overrides. The user can use the **Region and Language** application in **Control Panel** to customize an existing culture's property values.  
-  
-> [!NOTE]
->  You can use the <xref:System.Globalization.CultureAndRegionInfoBuilder> class to define, save, and register custom cultures that either supplement or replace existing cultures. The <xref:System.Globalization.CultureAndRegionInfoBuilder.Save%2A?displayProperty=nameWithType> method creates a Locale Data Markup Language (LDML) file that can be used to install a custom culture on target systems. For step-by step information on using the <xref:System.Globalization.CultureAndRegionInfoBuilder> class to create a new or replacement culture, see the <xref:System.Globalization.CultureAndRegionInfoBuilder> class topic.  
-  
+    
  Because the .NET Framework supports custom cultures, you should consider the following when working with culture-specific data:  
   
 -   Custom cultures can have values that exceed the ranges of the predefined cultures. For example, some cultures have unusually long month names, unexpected date or time formats, or other unusual data.  
@@ -374,7 +371,6 @@ In .NET Framework and .NET Core apps, the current culture is a per-thread settin
   
  ]]></format>
     </remarks>
-    <altmember cref="T:System.Globalization.CultureAndRegionInfoBuilder" />
     <altmember cref="T:System.Globalization.RegionInfo" />
   </Docs>
   <Members>
@@ -2064,7 +2060,6 @@ csc /resource:GreetingStrings.resources Example1.cs
 |Vietnamese|vi|en-US|  
 |Vietnamese (Vietnam)|vi-VN|en-US|  
   
- Your application can use <xref:System.Globalization.CultureAndRegionInfoBuilder> to create a replacement for a culture, and that culture can have a console fallback culture of your choosing.  
   
    
   
@@ -2389,7 +2384,6 @@ Setting `predefinedOnly` to `true` will ensure a culture is created only if the 
           <para>The [!INCLUDE[net_v35_long](~/includes/net-v35-long-md.md)] and earlier versions throw an <see cref="T:System.ArgumentException" /> if <paramref name="name" /> does not correspond to the name of a supported culture. Starting with the [!INCLUDE[net_v40_long](~/includes/net-v40-long-md.md)], this method throws a <see cref="T:System.Globalization.CultureNotFoundException" />.</para>
         </block>
         <altmember cref="P:System.Globalization.CultureInfo.TextInfo" />
-        <altmember cref="T:System.Globalization.CultureAndRegionInfoBuilder" />
         <altmember cref="M:System.Globalization.CultureInfo.ClearCachedData" />
       </Docs>
     </Member>
@@ -2664,7 +2658,6 @@ Setting `predefinedOnly` to `true` will ensure a culture is created only if the 
  ]]></format>
         </remarks>
         <altmember cref="P:System.Globalization.CultureInfo.TextInfo" />
-        <altmember cref="T:System.Globalization.CultureAndRegionInfoBuilder" />
       </Docs>
     </Member>
     <Member MemberName="InstalledUICulture">

--- a/xml/System.Globalization/CultureInfo.xml
+++ b/xml/System.Globalization/CultureInfo.xml
@@ -112,7 +112,7 @@
   
  Certain predefined culture names and identifiers are used by this and other classes in the <xref:System.Globalization?displayProperty=nameWithType> namespace. For detailed culture information for Windows systems, see the **Language tag** column in the [list of language/region names supported by Windows](https://docs.microsoft.com/openspecs/windows_protocols/ms-lcid/a9eac961-e77d-41a6-90a5-ce1a8b0cdb9c). Culture names follow the standard defined by [BCP 47](https://tools.ietf.org/html/bcp47).  
   
- Remember that the culture names and identifiers represent only a subset of cultures that can be found on a particular computer. Windows versions or service packs can change the available cultures. Applications add custom cultures using the <xref:System.Globalization.CultureAndRegionInfoBuilder> class. Users add their own custom cultures using the [Microsoft Locale Builder](https://www.microsoft.com/en-us/download/details.aspx?id=41158) tool. [Microsoft Locale Builder](https://www.microsoft.com/en-us/download/details.aspx?id=41158) is written in managed code using the `CultureAndRegionInfoBuilder` class.  
+ Remember that the culture names and identifiers represent only a subset of cultures that can be found on a particular computer. Windows versions or service packs can change the available cultures. Applications add custom cultures using the <xref:System.Globalization.CultureAndRegionInfoBuilder> class. Users add their own custom cultures using the [Microsoft Locale Builder](https://www.microsoft.com/en-us/download/details.aspx?id=41158) tool. 
   
  Several distinct names are closely associated with a culture, notably the names associated with the following class members:  
   
@@ -153,9 +153,8 @@
 -   Standard cultures with user overrides. The user can use the **Region and Language** application in **Control Panel** to customize an existing culture's property values.  
   
 > [!NOTE]
->  We recommend you to use the [Microsoft Locale Builder](https://www.microsoft.com/en-us/download/details.aspx?id=41158) to register your custom cultures on the Windows operating system.
->  Alternatively, in .NET Framework, you can use the <xref:System.Globalization.CultureAndRegionInfoBuilder> class to define, save, and register custom cultures that either supplement or replace existing cultures. The <xref:System.Globalization.CultureAndRegionInfoBuilder.Save%2A?displayProperty=nameWithType> method creates a Locale Data Markup Language (LDML) file that can be used to install a custom culture on target systems. For step-by step information on using the <xref:System.Globalization.CultureAndRegionInfoBuilder> class to create a new or replacement culture, see the <xref:System.Globalization.CultureAndRegionInfoBuilder> class topic.
-  
+>  You can use the [Microsoft Locale Builder](https://www.microsoft.com/en-us/download/details.aspx?id=41158) to create and register your custom cultures on the Windows operating system.
+
  Because the .NET supports custom cultures, you should consider the following when working with culture-specific data:  
   
 -   Custom cultures can have values that exceed the ranges of the predefined cultures. For example, some cultures have unusually long month names, unexpected date or time formats, or other unusual data.  


### PR DESCRIPTION
Remove reference to CultureAndRegionInfoBuilder that is unavailable in .NET 5.0

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
<!-- If the issue is found in <https://github.com/dotnet/docs, this takes the form "Fixes dotnet/docs#Issue_Number" -->

